### PR TITLE
fix: adjust subtitle size on apply page to better suit mobile devices

### DIFF
--- a/src/routes/Apply.css
+++ b/src/routes/Apply.css
@@ -61,6 +61,6 @@
   }
 
   .apply-banner-title {
-    font-size: 3rem !important;
+    font-size: 2.7rem !important;
   }
 }


### PR DESCRIPTION
## Description
Please see title.

## Related Issue
n/a

## Type of Change
- [ ] Update
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist
- [x] I have tested my changes locally
- [x] I have updated documentation where needed

## Screenshots

Screenshots taken using emulated Pixel 5.
Before:
<img width="507" height="419" alt="image" src="https://github.com/user-attachments/assets/c3681175-0261-40d5-b17a-cd2e4eda23b2" />
After:
<img width="541" height="376" alt="image" src="https://github.com/user-attachments/assets/7ca78282-5f45-4432-900c-8158b8566a1a" />