### PR TITLE
made whole box clickable

### DIFF
--- a/src/features/LinkItem/LinkItem.tsx
+++ b/src/features/LinkItem/LinkItem.tsx
@@ -28,11 +28,13 @@ const LinkItem = ({ title, link, category }: LinkItemProps) => {
     );
   } else {
     return (
-      <motion.button
-        whileHover={{ scale: 1.05 }}
-        className="w-full px-4 py-6 rounded-xl bg-black/20 border border-white backdrop-blur font-medium text-lg">
-        <DynamicLink link={link}>{title}</DynamicLink>
-      </motion.button>
+      <DynamicLink link={link} className="w-full">
+        <motion.div
+          whileHover={{ scale: 1.05 }}
+          className="w-full px-4 py-6 rounded-xl bg-black/20 border border-white backdrop-blur font-medium text-lg text-center cursor-pointer">
+          {title}
+        </motion.div>
+      </DynamicLink>
     );
   }
 };


### PR DESCRIPTION
## Description
Please explain the changes you made and why.
link page box was only clickable on the text of the item. Made whole box clickable.

## Related Issue
Link the issue this PR addresses.

## Type of Change
- [ ] Update
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist
- [ ] I have tested my changes locally
- [ ] I have updated documentation where needed

## Screenshots

If applicable, please add screenshots to help explain your changes. 



## Additional Information
(Anything else)